### PR TITLE
Reports do not start after a new installation due to a duplicate UUId  '90326ea2-f81e-11e6-bc64-92361f002671' in the schedule_task_config

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -35,12 +35,10 @@
         </insert>
     </changeSet>
 
-    <changeSet id="20200304-1748" author="slubwama" dbms="mysql">
+    <changeSet id="20200501-0918" author="slubwama" dbms="mysql">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT COUNT(*) FROM scheduler_task_config
-                WHERE schedulable_class = 'org.openmrs.module.ugandaemrsync.tasks.SendAllDataCentralServerTask'
-                And name = 'UgandaEMR Sync Task'
+                SELECT COUNT(*) FROM scheduler_task_config WHERE uuid = '90326ea2-f81e-11e6-bc64-92361f002671'
             </sqlCheck>
         </preConditions>
         <comment>Inserting  UgandaEMR Sync Task into 'schedule_task_config' table</comment>
@@ -55,6 +53,18 @@
             <column name="created_by" value="1" />
             <column name="uuid" value="90326ea2-f81e-11e6-bc64-92361f002671" />
         </insert>
+    </changeSet>
+
+    <changeSet id="ugandaemr-20200105-0917" author="slubwama">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM sync_task_type WHERE uuid = '90326ea2-f81e-11e6-bc64-92361f002671'
+            </sqlCheck>
+        </preConditions>
+        <comment>Change schedulable_class for task Synchronises Data to given Server</comment>
+        <sql>
+            UPDATE scheduler_task_config SET schedulable_class = 'org.openmrs.module.ugandaemrsync.tasks.SendAllDataCentralServerTask' WHERE uuid ='90326ea2-f81e-11e6-bc64-92361f002671';
+        </sql>
     </changeSet>
 
     <changeSet author="slubwama" id="ugandaemrsync-1561871469104-1">


### PR DESCRIPTION
Reports do not start after a new installation due to a duplicate UUId  '90326ea2-f81e-11e6-bc64-92361f002671' in the schedule_task_config
https://app.asana.com/0/1133167201254915/1173794211210361