### PR TITLE
Improve the performance of the Recency report generation

### DIFF
--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/UgandaEMRSyncConfig.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/UgandaEMRSyncConfig.java
@@ -56,6 +56,7 @@ public class UgandaEMRSyncConfig {
 	public static final String ANALYTICS_JSON_FILE_NAME = "Analytics_Metric_Report";
 
 	public static final String RECENCY_DATA_EXPORT_REPORT_DEFINITION_UUID = "662d4c00-d6bb-4494-8180-48776f415802";
+	public static final String GP_RECENCY_REPORT_DURATION = "ugandaemr.hts.recency.surveillance_report_coverage_months";
 
 	public static final String ANALYTICS_DATA_EXPORT_REPORT_DEFINITION_UUID = "dcd1f91a-04c8-4ae1-ac44-6abfdc91c98a";
 


### PR DESCRIPTION
https://app.asana.com/0/1201444627497339/1201445963728402/f

1. Remove the addition of the DHIS2 uuid which is included in the report
2. Set the report execution to run within the period specified by the report duration global variable 

