### PR TITLE
USM-29: Fix date casting to string that is causing errors in Viral load Program Data Synchronisation.

### DIFF
--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/api/UgandaEMRSyncService.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/api/UgandaEMRSyncService.java
@@ -70,6 +70,16 @@ public interface UgandaEMRSyncService extends OpenmrsService {
     @Transactional
     SyncTask getSyncTaskBySyncTaskId(String syncTaskId) throws APIException;
 
+
+    /**
+     * Gets a list of SyncTasks that matches the sync task parameter
+     * @param syncTaskId a string containing an id or uuid of the sync task
+     * @return List<SyncTask> that matches the sync task id or uuid in the parameter set
+     * @throws APIException
+     */
+    @Transactional
+    List<SyncTask> getSyncTasksBySyncTaskId(String syncTaskId) throws APIException;
+
     /**
      * Saves or updates the sync task set or given
      * @param syncTask the sync task that is to be saved

--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/api/dao/UgandaEMRSyncDao.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/api/dao/UgandaEMRSyncDao.java
@@ -75,6 +75,14 @@ public class UgandaEMRSyncDao {
                 .uniqueResult();
     }
 
+
+    /**
+     * @see org.openmrs.module.ugandaemrsync.api.UgandaEMRSyncService#getSyncTasksBySyncTaskId(java.lang.String)
+     */
+    public List<SyncTask> getSyncTasks(String syncTask) {
+        return (List<SyncTask>) getSession().createCriteria(SyncTask.class).add(Restrictions.eq("syncTask", syncTask)).list();
+    }
+
     /**
      * /**
      *

--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/api/impl/UgandaEMRSyncServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/api/impl/UgandaEMRSyncServiceImpl.java
@@ -126,6 +126,11 @@ public class UgandaEMRSyncServiceImpl extends BaseOpenmrsService implements Ugan
         return dao.getSyncTask(syncTaskId);
     }
 
+    @Override
+    public List<SyncTask> getSyncTasksBySyncTaskId(String syncTaskId) throws APIException {
+        return dao.getSyncTasks(syncTaskId);
+    }
+
     /**
      * @see org.openmrs.module.ugandaemrsync.api.UgandaEMRSyncService#getAllSyncTask()
      */

--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/server/SyncConstant.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/server/SyncConstant.java
@@ -466,9 +466,10 @@ public class SyncConstant {
 	public static List<String> FINGERPRINT_COLUMNS = Arrays.asList("patient", "finger", "fingerprint", "date_created",
 	    "facility", "state");
 
+
     public static final String VIRAL_LOAD_ENCOUNTER_QUERY = "select * from encounter inner join encounter_type on (encounter.encounter_type=encounter_type.encounter_type_id) where encounter_type.uuid='077c43ee-9745-11e9-bc42-526af7764f64'";
 
-    public static final String VIRAL_LOAD_ORDERS_QUERY = "select orders.order_id from orders  inner join test_order on (test_order.order_id=orders.order_id) inner JOIN concept ON (orders.concept_id = concept.concept_id) inner join concept_reference_map on (concept.concept_id = concept_reference_map.concept_id) inner join concept_reference_term on (concept_reference_map.concept_reference_term_id = concept_reference_term.concept_reference_term_id) where accession_number is not null  AND specimen_source is not null AND orders.instructions=\"REFER TO cphl\" AND code=315124004";
+    public static final String VIRAL_LOAD_ORDERS_QUERY = "select orders.order_id from orders  inner join test_order on (test_order.order_id=orders.order_id) where accession_number is not null AND specimen_source is not null AND orders.instructions=\"REFER TO cphl\" AND orders.concept_id=165412 and date_stopped is null;";
 
     public static final String VIRAL_LOAD_ORDER_QUERY = "select orders.order_id from orders  inner join test_order on (test_order.order_id=orders.order_id) where accession_number=\"%s\"";
 

--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/tasks/SendViralLoadProgramDataToCentralServerTask.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/tasks/SendViralLoadProgramDataToCentralServerTask.java
@@ -72,12 +72,11 @@ public class SendViralLoadProgramDataToCentralServerTask extends AbstractTask {
         SyncTaskType firstMessageSyncTaskType = ugandaEMRSyncService.getSyncTaskTypeByUUID(VIRAL_LOAD_SYNC_TYPE_UUID);
 
         for (Order order : orderList) {
-            List<SyncTask> allSyncTasks = ugandaEMRSyncService.getAllSyncTask();
-            List<SyncTask> syncTasks = allSyncTasks.stream().filter(p -> order.getAccessionNumber().equals(p.getSyncTask()) && syncTaskType.getId().equals(p.getSyncTaskType().getId())).collect(Collectors.toList());
-            List<SyncTask> firstSyncTaskToRun = allSyncTasks.stream().filter(p -> order.getAccessionNumber().equals(p.getSyncTask()) && firstMessageSyncTaskType.getId().equals(p.getSyncTaskType().getId())).collect(Collectors.toList());
+            List<SyncTask> allSyncTasks =  ugandaEMRSyncService.getSyncTasksBySyncTaskId(order.getAccessionNumber());
+            List<SyncTask> successfullVLProgramSyncTasks = allSyncTasks.stream().filter(p -> syncTaskType.getId().equals(p.getSyncTaskType().getId()) && (p.getStatusCode()==200 || p.getStatusCode()==201)).collect(Collectors.toList());
+            List<SyncTask> firstSyncTaskToRun = allSyncTasks.stream().filter(p -> firstMessageSyncTaskType.getId().equals(p.getSyncTaskType().getId())).collect(Collectors.toList());
 
-
-            if (syncTasks.size()<1 && firstSyncTaskToRun.size()>0) {
+            if (successfullVLProgramSyncTasks.size()<1 && firstSyncTaskToRun.size()>0) {
                 Map<String, String> dataOutput = generateVLProgramDataFHIRBody((TestOrder) order, VL_SEND_PROGRAM_DATA_FHIR_JSON_STRING);
                 String json = dataOutput.get("json");
 
@@ -212,7 +211,7 @@ public class SendViralLoadProgramDataToCentralServerTask extends AbstractTask {
             Date artStartDate = null;
             if(artStartList.size()>0){
                 ArrayList myList = (ArrayList) artStartList.get(0);
-                artStartDate = (Date) myList.get(0);
+                artStartDate = Context.getService(UgandaEMRSyncService.class).convertStringToDate(myList.get(0).toString(),"","yyyy-MM-dd'T'HH:mm");
             }
 
             List obs_indication_for_VL = administrationService.executeSQL(String.format(Latest_obs_of_Person,"value_coded", patientId,168689,date_activated),true);


### PR DESCRIPTION
Fix date casting to string that is causing errors in Viral load Program Data Synchronisation.
https://metsprogramme.atlassian.net/browse/USM-29

Optimize. Viral Load Query for getting orders that have viral load
https://metsprogramme.atlassian.net/browse/USM-28